### PR TITLE
Migrates client generator to `openapi-ts`

### DIFF
--- a/openapi-ts.config.ts
+++ b/openapi-ts.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "@hey-api/openapi-ts";
+
+export default defineConfig({
+  client: "axios",
+  input: "https://api.jutge.org/openapi.json",
+  base: "https://api.jutge.org",
+  output: "src/client",
+});

--- a/package.json
+++ b/package.json
@@ -121,10 +121,11 @@
     "pretest": "npm run compile && npm run lint",
     "lint": "eslint src --ext ts",
     "format": "prettier --write *",
-    "generate-client": "openapi --input https://api.jutge.org/documentation/json --output ./src/client --client axios --useUnionTypes",
+    "generate-client": "openapi-ts",
     "prepare": "husky install"
   },
   "devDependencies": {
+    "@hey-api/openapi-ts": "^0.42.1",
     "@types/mocha": "^10.0.6",
     "@types/node": "18.x",
     "@types/vscode": "^1.87.0",
@@ -137,7 +138,6 @@
     "eslint": "^8.56.0",
     "husky": "^9.0.11",
     "lint-staged": "^15.2.2",
-    "openapi-typescript-codegen": "^0.27.0",
     "prettier": "^3.2.5",
     "typescript": "^5.3.3"
   },

--- a/src/jutgeAuth.ts
+++ b/src/jutgeAuth.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 import axios from "axios";
 
-import { AuthenticationService } from "./client/services/AuthenticationService";
+import { AuthenticationService } from "./client";
 
 import { getExtensionContext } from "./context";
 
@@ -51,7 +51,7 @@ export async function signInToJutge() {
 
   let credentials;
   try {
-    credentials = await AuthenticationService.login({ email, password });
+    credentials = await AuthenticationService.login({ requestBody: { email, password } });
   } catch (error) {
     vscode.window.showErrorMessage("Jutge.org: Invalid credentials to sign in.");
     return;

--- a/src/jutgeSubmission.ts
+++ b/src/jutgeSubmission.ts
@@ -45,11 +45,11 @@ export async function submitProblemToJutge(problem: Problem, filePath: string): 
 
 async function monitorSubmissionStatus(problem: Problem, submissionId: string): Promise<any> {
   try {
-    const response = await MySubmissionsService.getSubmission(
-      problem.problem_nm,
-      problem.problem_id,
-      submissionId
-    );
+    const response = await MySubmissionsService.getSubmission({
+      problemNm: problem.problem_nm,
+      problemId: problem.problem_id,
+      submissionId: submissionId,
+    });
 
     if (response.veredict === SubmissionStatus.PENDING) {
       setTimeout(() => {

--- a/src/problemRunner.ts
+++ b/src/problemRunner.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 import * as fs from "fs";
 
-import { MyProblemsService } from "./client/services/MyProblemsService";
+import { MyProblemsService } from "./client";
 
 import { WebviewPanelHandler } from "./webviewProvider";
 import { getLanguageRunnerFromExtension } from "./languageRunner";
@@ -82,10 +82,10 @@ async function getProblemTestcases(problem: Problem): Promise<Testcase[] | undef
     return problem.testcases;
   }
   try {
-    const problemTestcases = (await MyProblemsService.getSampleTestcases(
-      problem.problem_nm,
-      problem.problem_id
-    )) as Testcase[];
+    const problemTestcases = (await MyProblemsService.getSampleTestcases({
+      problemNm: problem.problem_nm,
+      problemId: problem.problem_id,
+    })) as Testcase[];
     return problemTestcases;
   } catch (error) {
     console.error("Error getting problem testcases: ", error);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -61,7 +61,7 @@ export function getCompilerIdFromExtension(extension: string): string {
  */
 export async function isProblemValidAndAccessible(problemNm: string): Promise<boolean> {
   try {
-    const response = await MyProblemsService.getAbstractProblem(problemNm);
+    const response = await MyProblemsService.getAbstractProblem({ problemNm });
     return response !== undefined;
   } catch (error) {
     return false;

--- a/src/webviewProvider.ts
+++ b/src/webviewProvider.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 
-import { MyProblemsService } from "./client/services/MyProblemsService";
+import { MyProblemsService } from "./client";
 
 import {
   getNonce,
@@ -211,7 +211,9 @@ export class ProblemWebviewPanel {
    */
   private async _getProblemInfo(): Promise<void> {
     try {
-      const abstractProblem = await MyProblemsService.getAbstractProblem(this.problem.problem_nm);
+      const abstractProblem = await MyProblemsService.getAbstractProblem({
+        problemNm: this.problem.problem_nm,
+      });
       const langProblems = abstractProblem.problems;
       const availableLangIds = langProblems.reduce((acc: { [key: string]: any }, problem) => {
         acc[problem.language_id] = problem;
@@ -258,10 +260,10 @@ export class ProblemWebviewPanel {
       return this.problem.statementHtml;
     }
     try {
-      const problemStatement = await MyProblemsService.getTextStatement(
-        this.problem.problem_nm,
-        this.problem.problem_id
-      );
+      const problemStatement = (await MyProblemsService.getTextStatement({
+        problemNm: this.problem.problem_nm,
+        problemId: this.problem.problem_id,
+      })) as string;
       this.problem.statementHtml = problemStatement;
       return problemStatement;
     } catch (error) {
@@ -275,10 +277,10 @@ export class ProblemWebviewPanel {
       return this.problem.testcases;
     }
     try {
-      const problemTestcases = (await MyProblemsService.getSampleTestcases(
-        this.problem.problem_nm,
-        this.problem.problem_id
-      )) as Testcase[];
+      const problemTestcases = (await MyProblemsService.getSampleTestcases({
+        problemNm: this.problem.problem_nm,
+        problemId: this.problem.problem_id,
+      })) as Testcase[];
       this.problem.testcases = problemTestcases;
       return problemTestcases;
     } catch (error) {


### PR DESCRIPTION
Migrates OpenAPI generator client from deprecated [`openapi-typescript-codegen`](https://github.com/ferdikoomen/openapi-typescript-codegen) to [`openapi-ts`](https://github.com/hey-api/openapi-ts).

This solves the generator errors we had (e.g. the `Date` type is correctly inferred as the native one).