### PR TITLE
Adds config token source to Jutge Sign In

### DIFF
--- a/src/jutgeAuth.ts
+++ b/src/jutgeAuth.ts
@@ -50,21 +50,21 @@ async function getTokenFromCredentials(): Promise<string | undefined> {
 
   let credentials;
   try {
+    // Clear any existing token or `login` call will fail.
+    delete axios.defaults.headers.common["Authorization"];
     credentials = await AuthenticationService.login({ requestBody: { email, password } });
   } catch (error) {
     vscode.window.showErrorMessage("Jutge.org: Invalid credentials to sign in.");
+    console.log("Error signing in:", error);
     return;
   }
 
   await context.secrets.store("email", email);
-}
-
-function getTokenFromEnvironment(): string | undefined {
-  return process.env.JUTGE_API_TOKEN;
+  return credentials.token;
 }
 
 function getTokenFromConfigFile(): string | undefined {
-  // TODO: Search over several possible paths.
+  // TODO: Search over several possible paths (token, token.txt, etc.)
   const tokenFile = `${process.env.HOME}/.config/jutge/token.txt`;
   if (!fs.existsSync(tokenFile)) {
     return;
@@ -72,9 +72,27 @@ function getTokenFromConfigFile(): string | undefined {
   return fs.readFileSync(tokenFile, "utf8");
 }
 
+async function confirmUsingConfigToken(source_id: string): Promise<boolean> {
+  const source_name = {
+    config: "~/.config/jutge/token.txt",
+  }[source_id];
+
+  const result = await vscode.window.showInformationMessage(
+    `Jutge.org: Found a token in ${source_name}. Do you want to use it?`,
+    { modal: true },
+    "Yes"
+  );
+
+  return result === "Yes";
+}
+
 export async function signInToJutge() {
+  if (await isUserAuthenticated()) {
+    vscode.window.showInformationMessage("Jutge.org: You are already signed in.");
+    return;
+  }
+
   const token_getters = [
-    { id: "env", fn: getTokenFromEnvironment },
     { id: "config", fn: getTokenFromConfigFile },
     { id: "credentials", fn: getTokenFromCredentials },
   ];
@@ -82,8 +100,11 @@ export async function signInToJutge() {
   for (const getter of token_getters) {
     const token = await getter.fn();
     if (token) {
+      if (getter.id !== "credentials" && !(await confirmUsingConfigToken(getter.id))) {
+        continue;
+      }
       await getExtensionContext().secrets.store("jutgeToken", token);
-      axios.defaults.headers.common["Authorization"] = "Bearer " + token;
+      axios.defaults.headers.common["Authorization"] = `Bearer ${token}`;
 
       vscode.commands.executeCommand("jutge-vscode.refreshTree");
       vscode.window.showInformationMessage(


### PR DESCRIPTION
This PR adds the possibility to have the API token in a config file (`~/.config/jutge/token.txt`). 

When executing the `jutge-vscode.signIn` command, the extension will look at the config path (or any other we set up) before requesting the credentials. If any of these places have a token available, it will prompt the user to use that token to sign-in.